### PR TITLE
Update venv example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Er zijn vier sets opgaven die uiteindelijk in de voorlaatste week van periode 4.
 
 ## Opstarten
 
-De opgaven voor elke week gaan uit van een zipje met startcode. Het geheel gaat uit van een aantal dependencies. Deze dependencies hebben we voor het gemak in een [`requirements.txt`](files/requirements.txt) gezet. Je kunt het beste een virtuele omgeving aanmaken en hierin met pip in één keer alle dependencies installeren. Hier een voorbeeld voor MacOS:
+De opgaven voor elke week gaan uit van een zipje met startcode. Het geheel gaat uit van een aantal dependencies. Deze dependencies hebben we voor het gemak in een [`requirements.txt`](files/requirements.txt){: download="requirements.txt"} gezet. Je kunt het beste een virtuele omgeving aanmaken en hierin met pip in één keer alle dependencies installeren. Hier een voorbeeld voor MacOS:
 
 ```
 baba@aurelia ~ % python -m venv ml

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Er zijn vier sets opgaven die uiteindelijk in de voorlaatste week van periode 4.
 
 De opgaven voor elke week gaan uit van een zipje met startcode. Het geheel gaat uit van een aantal dependencies. Deze dependencies hebben we voor het gemak in een [`requirements.txt`](files/requirements.txt) gezet. Je kunt het beste een virtuele omgeving aanmaken en hierin met pip in één keer alle dependencies installeren. Hier een voorbeeld voor MacOS:
 
-```console
+```
 baba@aurelia ~ % python -m venv ml
 baba@aurelia ~ % cd ml 
 baba@aurelia ml % cp ~/Downloads/requirements.txt .
@@ -29,7 +29,7 @@ baba@aurelia ml % source bin/activate
 ```
 
 en voor Windows (Terminal/PowerShell)
-```console
+```
 PS C:\Users\ez> python -m venv ml
 PS C:\Users\ez> cd ml
 PS C:\Users\ez\ml> cp ~/Downloads/requirements.txt .

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,15 +18,25 @@ Er zijn vier sets opgaven die uiteindelijk in de voorlaatste week van periode 4.
 
 De opgaven voor elke week gaan uit van een zipje met startcode. Het geheel gaat uit van een aantal dependencies. Deze dependencies hebben we voor het gemak in een [`requirements.txt`](files/requirements.txt) gezet. Je kunt het beste een virtuele omgeving aanmaken en hierin met pip in één keer alle dependencies installeren. Hier een voorbeeld voor MacOS:
 
-```python
-baba@aurelia ~ % virtualenv ml
-created virtual environment CPython3.8.7.final.0-64 in 820ms
+```console
+baba@aurelia ~ % python -m venv ml
 baba@aurelia ~ % cd ml 
 baba@aurelia ml % cp ~/Downloads/requirements.txt .
 baba@aurelia ml % source bin/activate
 (ml) baba@aurelia ml % python -m pip install -r requirements.txt 
 ...
 (ml) baba@aurelia ml % 
+```
+
+en voor Windows (Terminal/PowerShell)
+```console
+PS C:\Users\ez> python -m venv ml
+PS C:\Users\ez> cd ml
+PS C:\Users\ez\ml> cp ~/Downloads/requirements.txt .
+PS C:\Users\ez\ml> Scripts/activate
+(ml) PS C:\Users\ez\ml> python -m pip install -r requirements.txt
+...
+(ml) PS C:\Users\ez\ml> 
 ```
 
 ## Globale planning

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tilde
   - pymdownx.tabbed
+  - attr_list
 
 extra_javascript:
   - js/imgs.js


### PR DESCRIPTION
Deze PR bevat een update van het venv-voorbeeld om gebruik te maken van de `venv`-module welke standaard bijgeleverd wordt met een installatie van Python >3.3. (`virtualenv` werkt normaal gesproken niet bij nieuwe installaties van Python).

Ik heb ook een voorbeeld voor Windows gebruikers toegevoegd.