### PR TITLE
make cores-dimensions dynamic to X-parameter (like anomalies/non-cores)

### DIFF
--- a/docs/deel3/opgaven/opgave3-3.ipynb
+++ b/docs/deel3/opgaven/opgave3-3.ipynb
@@ -66,7 +66,7 @@
     "    anomalies_mask = model.labels_ == -1\n",
     "    non_core_mask = ~(core_mask | anomalies_mask)\n",
     "\n",
-    "    cores = model.components_\n",
+    "    cores = X[core_mask]\n",
     "    anomalies = X[anomalies_mask]\n",
     "    non_cores = X[non_core_mask]\n",
     "    \n",


### PR DESCRIPTION
Tijdens de oplevering kwamen we er achter dat de plots van de DBSCAN bij een groei van het aantal herkende core-punten juist meer ging lijken op de 1e en 2e dimensie van X, ongeacht de meegegeven dimensie aan de `plot_dbscan()` functie. 

Deze verandering zorgt ervoor dat de dimensies van de `cores` overeenkomen met de dimensies van `anomalies` en `non-cores`, zodat de `plot_dbscan(model, X)` aangeroepen kan worden met een slice van X, zoals `plot_dbscan(model, X[:, 2:4], xlabel='petal length', ylabel='petal width')`.

(Met `cores = model.components_`)
![image](https://github.com/user-attachments/assets/2a264890-ec6c-4f73-ae78-0187b1b8a306)

(Met `cores = X[core_mask]`)
![image](https://github.com/user-attachments/assets/2df8e7c1-0aa9-40ce-b5a5-57b02176df55)


